### PR TITLE
adding gatsby-plugin-emotion

### DIFF
--- a/2019/gatsby-config.js
+++ b/2019/gatsby-config.js
@@ -36,6 +36,7 @@ module.exports = {
         },
       },
     },
+    `gatsby-plugin-emotion`,
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/2019/package-lock.json
+++ b/2019/package-lock.json
@@ -883,6 +883,25 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emotion/babel-plugin-jsx-pragmatic": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.2.tgz",
+      "integrity": "sha512-BapTL0I1flAB+qrfOmltOdLORBtz8dvtKjcHZmYYWdiGsn+2bZxaZDra+S0jDLd1tnhvPvhHoGv3140WR8PAow==",
+      "requires": {
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@emotion/babel-preset-css-prop": {
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.0.9.tgz",
+      "integrity": "sha512-fETOWFEe734RlJZTuq6+NeHTzl+Kge4yRm3yrQC+Y2I+KxZjYiU5XUPdbylr0EATbkSzFXgVGKppciZfA5j1mw==",
+      "requires": {
+        "@babel/plugin-transform-react-jsx": "^7.1.6",
+        "@emotion/babel-plugin-jsx-pragmatic": "^0.1.2",
+        "babel-plugin-emotion": "^10.0.9",
+        "object-assign": "^4.1.1"
+      }
+    },
     "@emotion/cache": {
       "version": "10.0.9",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.9.tgz",
@@ -5691,8 +5710,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5710,13 +5728,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5729,18 +5745,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5843,8 +5856,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5854,7 +5866,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5867,20 +5878,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5897,7 +5905,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5970,8 +5977,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5981,7 +5987,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6057,8 +6062,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6088,7 +6092,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6106,7 +6109,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6145,13 +6147,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -6547,6 +6547,15 @@
         "@babel/runtime": "^7.0.0",
         "@types/reach__router": "^1.0.0",
         "prop-types": "^15.6.1"
+      }
+    },
+    "gatsby-plugin-emotion": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.0.6.tgz",
+      "integrity": "sha512-cBCGVdNkULlrYMPsrCVDKrCxiKpZq4PL9n5qzQ538FWmg+XqBhQKWaH8dALwEzoDS5GyHXQy1hI7XHoWmDBJAQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@emotion/babel-preset-css-prop": "^10.0.5"
       }
     },
     "gatsby-plugin-flow": {

--- a/2019/package.json
+++ b/2019/package.json
@@ -10,6 +10,7 @@
     "emotion-theming": "^10.0.10",
     "gatsby": "^2.3.16",
     "gatsby-image": "^2.0.37",
+    "gatsby-plugin-emotion": "^4.0.6",
     "gatsby-plugin-flow": "^1.0.4",
     "gatsby-plugin-manifest": "^2.0.28",
     "gatsby-plugin-offline": "^2.0.25",

--- a/2019/src/components/landing-page.js
+++ b/2019/src/components/landing-page.js
@@ -18,6 +18,7 @@ import { Box } from "./layout-components"
 
 const Wrap = styled(Box.withComponent("main"))`
   min-height: 100vh;
+  overflow-x: hidden;
   @supports (display: grid) {
     min-height: 0;
   }


### PR DESCRIPTION
adding gatsby-plugin-emotion to see if that will help with the inconsistent css between develop and build with gatsby

in one issue where someone was using styled components, he mentioned adding `gatsby-plugin-styled-components in gatsby-config.js` worked for him.
https://github.com/gatsbyjs/gatsby/issues/9911

https://www.gatsbyjs.org/packages/gatsby-plugin-emotion/